### PR TITLE
Run sub-Python processes under env and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-__pycache__/database_config.cpython-310.pyc
+__pycache__/
+.idea/
+logs/
+venv/
 config.toml
-__pycache__/db_manager.cpython-310.pyc
-__pycache__/logging_utility cpython 39.pyc
-__pycache__/logging_utility cpython 310.pyc
-__pycache__/logging_utility.cpython-310.pyc
-__pycache__/utilities.cpython-310.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ __pycache__/
 .idea/
 logs/
 venv/
-config.toml
 ableton_live_sets.db

--- a/main.py
+++ b/main.py
@@ -1,8 +1,6 @@
 import os
-import signal
 import subprocess
 import sys
-
 import toml
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -1,5 +1,8 @@
 import os
+import signal
 import subprocess
+import sys
+
 import toml
 
 if __name__ == '__main__':
@@ -10,8 +13,16 @@ if __name__ == '__main__':
     if os.path.exists(config["database_path"]["path"].replace("{USER_HOME}", user_home_dir)):
         os.remove(config["database_path"]["path"].replace("{USER_HOME}", user_home_dir))
 
-    process = subprocess.Popen(['python', os.path.join('db_manager.py')])
-    process.wait()
-    process = subprocess.Popen(['python', os.path.join('file_watcher.py')])
+    db_process = subprocess.Popen([sys.executable, os.path.join('db_manager.py')])
+    db_process.wait()
+
+    file_process = None
+    try:
+        file_process = subprocess.Popen([sys.executable, os.path.join('file_watcher.py')])
+        file_process.wait()
+    except KeyboardInterrupt:
+        # Handle Ctrl+C gracefully
+        file_process.send_signal(signal.SIGINT)
+
     # commented out because it doesn't work properly right now.
-    # subprocess.call(['python', os.path.join('gui.py')])
+    # subprocess.call([sys.executable, os.path.join('gui.py')])

--- a/main.py
+++ b/main.py
@@ -16,11 +16,7 @@ if __name__ == '__main__':
     db_process = subprocess.Popen([sys.executable, os.path.join('db_manager.py')])
     db_process.wait()
 
-    file_process = None
-    try:
-        file_process = subprocess.Popen([sys.executable, os.path.join('file_watcher.py')])
-        file_process.wait()
-        subprocess.call([sys.executable, os.path.join('gui.py')])
-    except KeyboardInterrupt:
-        # Handle Ctrl+C gracefully
-        file_process.send_signal(signal.SIGINT)
+    subprocess.Popen([sys.executable, os.path.join('file_watcher.py')])
+
+    # Blocks until GUI is closed, then program ends
+    subprocess.call([sys.executable, os.path.join('gui.py')])


### PR DESCRIPTION
Uses `sys.executable` instead of `python` to execute Python subprocesses. This allows for keeping subprocesses inside the running virtualenv, and handles nuances where `python` is named `python3` on some systems.

Updates `.gitignore` to ignore the following directories entirely:
- \_\_pycache\_\_/
- .idea/
- logs/
- venv/